### PR TITLE
Ghost URL Typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@
 
 ### Tutorials
 - [Getting Started with Gridsome](https://scotch.io/tutorials/getting-started-with-gridsome)
-- [Working with Ghost and Gridsome](https://ghost.org/docs/api/v2/gridsome/)
+- [Working with Ghost and Gridsome](https://ghost.org/docs/api/gridsome/)
 
 ### Starters
 #### Official


### PR DESCRIPTION
Our documentation uses a specific URL pattern to ensure people are directed to the latest version of our docs, hence the removal of `v2/` in this case. Thanks!