### PR TITLE
Remove website from showcase

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,6 @@
 - [sergeyfilimonov.com](https://sergeyfilimonov.com) - Personal website of a fullstack designer.
 - [hr.netology.ru](https://hr.netology.ru) - Online courses on HR for one of the biggest online education companies in Russia.
 - [Agregador FC](https://atilacamurca.github.io/agregador-fc/) - Website to help assemble a team to play [Cartola FC](https://cartolafc.globo.com/), a fantasy soccer game from Brazil. It shows statistics about the teams that will face each other.
-- [Iman Sugirman](https://imansugirman.com/) - Personal website of a tutorial Laravel, Ruby on Rails, Wordpress, Cloud Server Indonesia Language.
 - [BarbaDev](https://barbadev.netlify.com/) - Personal blog from Fernando M. @packtpub author, built with Tailwind CSS and Gridsome.
 - [Built with Gridsome](https://builtwithgridso.me) - Showcase of projects built with Gridsome.
 - [maciejkulczewski.de](https://maciejkulczewski.de) - Portfolio and showcase build with Gridsome.


### PR DESCRIPTION
https://imansugirman.com/ website wasn't built with Gridsome, it uses Jigsaw. It's written on the website footer.

